### PR TITLE
add customer export with csv abd vcf

### DIFF
--- a/src/renderer/src/pages/Customers.tsx
+++ b/src/renderer/src/pages/Customers.tsx
@@ -48,6 +48,9 @@ export default function Customers(): JSX.Element {
   const [deleteCheckResult, setDeleteCheckResult] = useState<any>(null)
   const [customerToDelete, setCustomerToDelete] = useState<Customer | null>(null)
 
+  // Export dropdown state
+  const [showExportDropdown, setShowExportDropdown] = useState(false)
+
   // Debounce search input
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -337,35 +340,72 @@ export default function Customers(): JSX.Element {
           <p className="text-slate-600 dark:text-slate-400 mt-1">Manage customer relationships and loyalty</p>
         </div>
         <div className="flex items-center gap-3">
-          {/* Export Dropdown */}
-          <div className="relative group">
-            <button className="btn-secondary flex items-center gap-2">
+          {/* Export Dropdown - Accessible with keyboard and screen readers */}
+          <div className="relative">
+            <button 
+              className="btn-secondary flex items-center gap-2"
+              onClick={() => setShowExportDropdown(!showExportDropdown)}
+              onBlur={(e) => {
+                // Close dropdown if focus leaves the dropdown container
+                if (!e.currentTarget.parentElement?.contains(e.relatedTarget as Node)) {
+                  setShowExportDropdown(false)
+                }
+              }}
+              aria-expanded={showExportDropdown}
+              aria-haspopup="true"
+            >
               <Download size={20} />
               Export
             </button>
-            <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-slate-800 rounded-lg shadow-xl border border-slate-200 dark:border-slate-700 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-10">
-              <button
-                onClick={() => handleExport('excel')}
-                className="w-full px-4 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-2 rounded-t-lg"
+            {showExportDropdown && (
+              <div 
+                className="absolute right-0 mt-2 w-48 bg-white dark:bg-slate-800 rounded-lg shadow-xl border border-slate-200 dark:border-slate-700 z-10"
+                role="menu"
               >
-                <FileSpreadsheet size={18} className="text-green-600" />
-                <span>Excel (.xlsx)</span>
-              </button>
-              <button
-                onClick={() => handleExport('csv')}
-                className="w-full px-4 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-2"
-              >
-                <FileText size={18} className="text-blue-600" />
-                <span>CSV (.csv)</span>
-              </button>
-              <button
-                onClick={() => handleExport('vcf')}
-                className="w-full px-4 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-2 rounded-b-lg"
-              >
-                <User size={18} className="text-purple-600" />
-                <span>vCard (.vcf)</span>
-              </button>
-            </div>
+                <button
+                  onClick={() => {
+                    handleExport('excel')
+                    setShowExportDropdown(false)
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Escape') setShowExportDropdown(false)
+                  }}
+                  className="w-full px-4 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-2 rounded-t-lg"
+                  role="menuitem"
+                >
+                  <FileSpreadsheet size={18} className="text-green-600" />
+                  <span>Excel (.xlsx)</span>
+                </button>
+                <button
+                  onClick={() => {
+                    handleExport('csv')
+                    setShowExportDropdown(false)
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Escape') setShowExportDropdown(false)
+                  }}
+                  className="w-full px-4 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-2"
+                  role="menuitem"
+                >
+                  <FileText size={18} className="text-blue-600" />
+                  <span>CSV (.csv)</span>
+                </button>
+                <button
+                  onClick={() => {
+                    handleExport('vcf')
+                    setShowExportDropdown(false)
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Escape') setShowExportDropdown(false)
+                  }}
+                  className="w-full px-4 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-2 rounded-b-lg"
+                  role="menuitem"
+                >
+                  <User size={18} className="text-purple-600" />
+                  <span>vCard (.vcf)</span>
+                </button>
+              </div>
+            )}
           </div>
           
           <button


### PR DESCRIPTION
This pull request adds a comprehensive customer export feature to the application, allowing users to export customer data in Excel, CSV, or vCard (VCF) formats. The export supports filtering by search terms and includes a user interface for selecting the export format. The backend handles data formatting and file generation, while the frontend provides an intuitive dropdown for export actions.

**Backend: Customer Export Functionality**

* Added a new `customers:export` IPC handler in `customers.handlers.ts` to support exporting customer data in Excel (`.xlsx`), CSV (`.csv`), and vCard (`.vcf`) formats, including recalculation of `totalSpent` and filtering by search term.
* Introduced the `xlsx` library for Excel and CSV file generation.

**Frontend: UI and Export Handling**

* Added a dropdown export menu to the Customers page, allowing users to choose between Excel, CSV, and vCard export options, each with appropriate icons and styling.
* Implemented the `handleExport` function in `Customers.tsx` to trigger the export, handle file downloads, and display success or error toasts to the user.
* Imported new icons for export actions to enhance the user interface.