### PR TITLE
add an option to change the receipt language

### DIFF
--- a/src/main/services/ThermalPrinterService.ts
+++ b/src/main/services/ThermalPrinterService.ts
@@ -26,6 +26,7 @@ export interface PrinterSettings {
   printQRCode?: boolean
   printBarcode?: boolean
   openCashDrawer?: boolean
+  receiptLanguage?: 'en' | 'ar'
 }
 
 export interface ReceiptData {
@@ -149,9 +150,67 @@ export class ThermalPrinterService {
   }
 
   /**
+   * Get receipt label strings in English or Arabic
+   */
+  private static getReceiptLabels(lang: 'en' | 'ar') {
+    if (lang === 'ar') {
+      return {
+        tel: 'هاتف',
+        taxNo: 'الرقم الضريبي',
+        commReg: 'السجل التجاري',
+        receiptNum: 'رقم الإيصال',
+        date: 'التاريخ',
+        cashier: 'الكاشير',
+        customer: 'العميل',
+        phone: 'الهاتف',
+        subtotal: 'المجموع الفرعي',
+        vat: 'ضريبة القيمة المضافة',
+        total: 'الاجمالي الكلي',
+        payment: 'طريقة الدفع',
+        discount: 'خصم',
+        afterDiscount: 'بعد الخصم',
+        fixedDiscount: 'خصم ثابت',
+        installmentPlan: 'خطة الاقساط',
+        depositPaid: 'الدفعة المقدمة',
+        remaining: 'المتبقي',
+        statusPaid: 'مدفوع',
+        statusOverdue: 'متاخر',
+        thankYou: 'شكرا لزيارتكم!',
+        appreciate: 'نقدر تعاملكم معنا',
+      }
+    }
+    return {
+      tel: 'Tel',
+      taxNo: 'Tax No',
+      commReg: 'Comm Reg',
+      receiptNum: 'Receipt #',
+      date: 'Date',
+      cashier: 'Cashier',
+      customer: 'Customer',
+      phone: 'Phone',
+      subtotal: 'Subtotal',
+      vat: 'VAT',
+      total: 'TOTAL',
+      payment: 'Payment',
+      discount: 'Discount',
+      afterDiscount: 'After Discount',
+      fixedDiscount: 'Fixed Discount',
+      installmentPlan: 'INSTALLMENT PLAN',
+      depositPaid: 'Deposit Paid',
+      remaining: 'Remaining',
+      statusPaid: 'PAID',
+      statusOverdue: 'OVERDUE',
+      thankYou: 'Thank you for your visit!',
+      appreciate: 'We appreciate your business',
+    }
+  }
+
+  /**
    * Format receipt as plain text for thermal printing
    */
   private static formatReceiptText(data: ReceiptData, settings: PrinterSettings): string {
+    const lbl = this.getReceiptLabels(settings.receiptLanguage || 'en')
+    const locale = settings.receiptLanguage === 'ar' ? 'ar-EG' : 'en-US'
     const width = settings.paperWidth === '80mm' ? 48 : 32
     const line = '='.repeat(width)
     const dashes = '-'.repeat(width)
@@ -161,20 +220,20 @@ export class ThermalPrinterService {
     // Store name (centered)
     text += data.storeName.toUpperCase() + '\n'
     text += data.storeAddress + '\n'
-    text += `Tel: ${data.storePhone}\n`
+    text += `${lbl.tel}: ${data.storePhone}\n`
     if (data.storeEmail) text += data.storeEmail + '\n'
     text += '\n'
     
     // Tax info
     text += dashes + '\n'
-    text += `Tax No: ${data.taxNumber}\n`
-    if (data.commercialRegister) text += `Comm Reg: ${data.commercialRegister}\n`
+    text += `${lbl.taxNo}: ${data.taxNumber}\n`
+    if (data.commercialRegister) text += `${lbl.commReg}: ${data.commercialRegister}\n`
     text += dashes + '\n'
     text += '\n'
     
     // Receipt info
-    text += `Receipt #: ${data.receiptNumber}\n`
-    text += `Date: ${data.date.toLocaleString('en-US', {
+    text += `${lbl.receiptNum}: ${data.receiptNumber}\n`
+    text += `${lbl.date}: ${data.date.toLocaleString(locale, {
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',
@@ -182,9 +241,9 @@ export class ThermalPrinterService {
       minute: '2-digit',
       hour12: true
     })}\n`
-    if (data.username) text += `Cashier: ${data.username}\n`
-    if (data.customerName) text += `Customer: ${data.customerName}\n`
-    if (data.customerPhone) text += `Phone: ${data.customerPhone}\n`
+    if (data.username) text += `${lbl.cashier}: ${data.username}\n`
+    if (data.customerName) text += `${lbl.customer}: ${data.customerName}\n`
+    if (data.customerPhone) text += `${lbl.phone}: ${data.customerPhone}\n`
     text += dashes + '\n'
     
     // Items with discount calculation
@@ -212,11 +271,11 @@ export class ThermalPrinterService {
       text += `${item.quantity} x ${originalPrice.toFixed(2)} = ${originalTotal.toFixed(2)} EGP\n`
       
       if (hasDiscount) {
-        const discountLabel = item.discountType === 'PERCENTAGE' 
-          ? `Discount ${item.discountValue}%` 
-          : 'Fixed Discount'
+        const discountLabel = item.discountType === 'PERCENTAGE'
+          ? `${lbl.discount} ${item.discountValue}%`
+          : lbl.fixedDiscount
         text += `${discountLabel}: -${itemDiscount.toFixed(2)} EGP\n`
-        text += `After Discount: ${finalTotal.toFixed(2)} EGP\n`
+        text += `${lbl.afterDiscount}: ${finalTotal.toFixed(2)} EGP\n`
       }
       
       text += dashes + '\n'
@@ -224,31 +283,31 @@ export class ThermalPrinterService {
     
     // Totals
     text += '\n'
-    text += `Subtotal: ${data.subtotal.toFixed(2)} EGP\n`
-    text += `VAT (${data.taxRate}%): ${data.tax.toFixed(2)} EGP\n`
+    text += `${lbl.subtotal}: ${data.subtotal.toFixed(2)} EGP\n`
+    text += `${lbl.vat} (${data.taxRate}%): ${data.tax.toFixed(2)} EGP\n`
     text += line + '\n'
-    text += `TOTAL: ${data.total.toFixed(2)} EGP\n`
+    text += `${lbl.total}: ${data.total.toFixed(2)} EGP\n`
     text += line + '\n'
     text += '\n'
     
     // Payment
-    text += `Payment: ${data.paymentMethod}\n`
+    text += `${lbl.payment}: ${data.paymentMethod}\n`
     
     // Installments
     if (data.installments && data.installments.length > 0) {
       text += '\n'
       text += dashes + '\n'
-      text += 'INSTALLMENT PLAN\n'
+      text += `${lbl.installmentPlan}\n`
       text += dashes + '\n'
       
       if (data.depositAmount) {
-        text += `Deposit Paid: ${data.depositAmount.toFixed(2)} EGP\n`
+        text += `${lbl.depositPaid}: ${data.depositAmount.toFixed(2)} EGP\n`
         text += '\n'
       }
       
       data.installments.forEach((inst, idx) => {
-        const status = inst.status === 'paid' ? ' PAID' : inst.status === 'overdue' ? ' OVERDUE' : ''
-        const dateStr = inst.dueDate.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: '2-digit' })
+        const status = inst.status === 'paid' ? ` ${lbl.statusPaid}` : inst.status === 'overdue' ? ` ${lbl.statusOverdue}` : ''
+        const dateStr = inst.dueDate.toLocaleDateString(locale, { month: '2-digit', day: '2-digit', year: '2-digit' })
         text += `#${idx + 1} ${dateStr}\n`
         text += `   ${inst.amount.toFixed(2)} EGP${status}\n`
       })
@@ -258,12 +317,12 @@ export class ThermalPrinterService {
         .reduce((sum, i) => sum + i.amount, 0)
       
       text += dashes + '\n'
-      text += `Remaining: ${remaining.toFixed(2)} EGP\n`
+      text += `${lbl.remaining}: ${remaining.toFixed(2)} EGP\n`
     }
     
     text += '\n'
-    text += 'Thank you for your visit!\n'
-    text += 'We appreciate your business\n'
+    text += `${lbl.thankYou}\n`
+    text += `${lbl.appreciate}\n`
     
     // Add blank lines for easy tearing
     const blankLines = settings.receiptBottomSpacing ?? 4
@@ -310,7 +369,9 @@ export class ThermalPrinterService {
    * Format and print receipt
    */
   private static async formatAndPrintReceipt(printer: ThermalPrinter, data: ReceiptData, settings: PrinterSettings): Promise<void> {
-    
+    const lbl = this.getReceiptLabels(settings.receiptLanguage || 'en')
+    const locale = settings.receiptLanguage === 'ar' ? 'ar-EG' : 'en-US'
+
     // Store info
     printer.alignCenter()
     printer.bold(true)
@@ -319,7 +380,7 @@ export class ThermalPrinterService {
     printer.bold(false)
     printer.setTextNormal()
     printer.println(data.storeAddress)
-    printer.println(`Tel: ${data.storePhone}`)
+    printer.println(`${lbl.tel}: ${data.storePhone}`)
     if (data.storeEmail) {
       printer.println(data.storeEmail)
     }
@@ -327,17 +388,17 @@ export class ThermalPrinterService {
 
     // Tax info
     printer.drawLine()
-    printer.println(`Tax No: ${data.taxNumber}`)
+    printer.println(`${lbl.taxNo}: ${data.taxNumber}`)
     if (data.commercialRegister) {
-      printer.println(`Comm Reg: ${data.commercialRegister}`)
+      printer.println(`${lbl.commReg}: ${data.commercialRegister}`)
     }
     printer.drawLine()
     printer.newLine()
 
     // Receipt info
     printer.alignLeft()
-    printer.println(`Receipt #: ${data.receiptNumber}`)
-    printer.println(`Date: ${data.date.toLocaleString('en-US', {
+    printer.println(`${lbl.receiptNum}: ${data.receiptNumber}`)
+    printer.println(`${lbl.date}: ${data.date.toLocaleString(locale, {
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',
@@ -346,13 +407,13 @@ export class ThermalPrinterService {
       hour12: true
     })}`)
     if (data.username) {
-      printer.println(`Cashier: ${data.username}`)
+      printer.println(`${lbl.cashier}: ${data.username}`)
     }
     if (data.customerName) {
-      printer.println(`Customer: ${data.customerName}`)
+      printer.println(`${lbl.customer}: ${data.customerName}`)
     }
     if (data.customerPhone) {
-      printer.println(`Phone: ${data.customerPhone}`)
+      printer.println(`${lbl.phone}: ${data.customerPhone}`)
     }
     printer.drawLine()
 
@@ -381,11 +442,11 @@ export class ThermalPrinterService {
       printer.println(`${item.quantity} x ${originalPrice.toFixed(2)} = ${originalTotal.toFixed(2)} EGP`)
       
       if (hasDiscount && item.discountValue !== undefined) {
-        const discountLabel = item.discountType === 'PERCENTAGE' 
-          ? `Discount ${item.discountValue}%` 
-          : 'Fixed Discount'
+        const discountLabel = item.discountType === 'PERCENTAGE'
+          ? `${lbl.discount} ${item.discountValue}%`
+          : lbl.fixedDiscount
         printer.println(`${discountLabel}: -${itemDiscount.toFixed(2)} EGP`)
-        printer.println(`After Discount: ${finalTotal.toFixed(2)} EGP`)
+        printer.println(`${lbl.afterDiscount}: ${finalTotal.toFixed(2)} EGP`)
       }
       
       printer.drawLine()
@@ -393,12 +454,12 @@ export class ThermalPrinterService {
 
     // Totals
     printer.newLine()
-    printer.println(`Subtotal: ${data.subtotal.toFixed(2)} EGP`)
-    printer.println(`VAT (${data.taxRate}%): ${data.tax.toFixed(2)} EGP`)
+    printer.println(`${lbl.subtotal}: ${data.subtotal.toFixed(2)} EGP`)
+    printer.println(`${lbl.vat} (${data.taxRate}%): ${data.tax.toFixed(2)} EGP`)
     printer.drawLine()
     printer.bold(true)
     printer.setTextSize(1, 1)
-    printer.println(`TOTAL: ${data.total.toFixed(2)} EGP`)
+    printer.println(`${lbl.total}: ${data.total.toFixed(2)} EGP`)
     printer.bold(false)
     printer.setTextNormal()
     printer.drawLine()
@@ -406,7 +467,7 @@ export class ThermalPrinterService {
     // Payment
     printer.newLine()
     printer.alignCenter()
-    printer.println(`Payment: ${data.paymentMethod}`)
+    printer.println(`${lbl.payment}: ${data.paymentMethod}`)
     
     // Installments
     if (data.installments && data.installments.length > 0) {
@@ -414,19 +475,19 @@ export class ThermalPrinterService {
       printer.drawLine()
       printer.alignCenter()
       printer.bold(true)
-      printer.println('INSTALLMENT PLAN')
+      printer.println(lbl.installmentPlan)
       printer.bold(false)
       printer.drawLine()
       printer.alignLeft()
       
       if (data.depositAmount) {
-        printer.println(`Deposit: ${data.depositAmount.toFixed(2)} EGP`)
+        printer.println(`${lbl.depositPaid}: ${data.depositAmount.toFixed(2)} EGP`)
         printer.drawLine()
       }
       
       data.installments.forEach((inst, idx) => {
-        const status = inst.status === 'paid' ? 'PAID' : inst.status === 'overdue' ? 'OVER' : 'DUE'
-        const dateStr = inst.dueDate.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: '2-digit' })
+        const status = inst.status === 'paid' ? lbl.statusPaid : inst.status === 'overdue' ? lbl.statusOverdue : 'DUE'
+        const dateStr = inst.dueDate.toLocaleDateString(locale, { month: '2-digit', day: '2-digit', year: '2-digit' })
         printer.println(`#${idx + 1} ${dateStr}`)
         printer.println(`   ${inst.amount.toFixed(2)} EGP - ${status}`)
       })
@@ -437,14 +498,14 @@ export class ThermalPrinterService {
       
       printer.drawLine()
       printer.bold(true)
-      printer.println(`Remaining: ${remaining.toFixed(2)} EGP`)
+      printer.println(`${lbl.remaining}: ${remaining.toFixed(2)} EGP`)
       printer.bold(false)
     }
     
     printer.newLine()
     printer.alignCenter()
-    printer.println('Thank you for your visit!')
-    printer.println('We appreciate your business')
+    printer.println(lbl.thankYou)
+    printer.println(lbl.appreciate)
 
     // Add spacing
     const blankLines = settings.receiptBottomSpacing ?? 4

--- a/src/renderer/src/pages/Sales/ReceiptPreviewModal.tsx
+++ b/src/renderer/src/pages/Sales/ReceiptPreviewModal.tsx
@@ -13,6 +13,83 @@ export function ReceiptPreviewModal({ transaction, onClose }: ReceiptPreviewModa
   const [settings, setSettings] = useState<any>(null)
   const [isPrinting, setIsPrinting] = useState(false)
   const [autoPrintTriggered, setAutoPrintTriggered] = useState(false)
+  const [receiptLang, setReceiptLang] = useState<'en' | 'ar'>(
+    () => (localStorage.getItem('receiptLanguage') as 'en' | 'ar') || 'en'
+  )
+
+  const L = receiptLang === 'ar' ? {
+    receiptPreview: 'معاينة الإيصال',
+    tel: 'هاتف',
+    taxNo: 'الرقم الضريبي',
+    commReg: 'السجل التجاري',
+    receiptNum: 'رقم الإيصال',
+    date: 'التاريخ',
+    cashier: 'الكاشير',
+    customer: 'العميل',
+    phone: 'الهاتف',
+    item: 'الصنف',
+    qty: 'الكمية',
+    price: 'السعر',
+    total: 'الإجمالي',
+    subtotal: 'المجموع الفرعي',
+    vat: 'ضريبة القيمة المضافة',
+    grandTotal: 'الإجمالي الكلي',
+    payment: 'طريقة الدفع',
+    cash: 'نقدي',
+    card: 'بطاقة بنكية',
+    installmentLabel: 'تقسيط',
+    other: 'أخرى',
+    afterDiscount: 'بعد الخصم',
+    fixedDiscount: 'خصم ثابت',
+    percentOff: '% خصم',
+    installmentPlan: 'خطة الأقساط',
+    depositPaid: 'الدفعة المقدمة',
+    remaining: 'المتبقي',
+    installmentPayment: 'قسط',
+    walkIn: 'زبون عابر',
+    unknown: 'غير معروف',
+    thankYou: 'شكراً لزيارتكم!',
+    appreciate: 'نقدر تعاملكم معنا',
+    printBrowser: 'طباعة (متصفح)',
+    printThermal: 'طباعة (حراري)',
+    printing: 'جارِ الطباعة...',
+  } : {
+    receiptPreview: 'Receipt Preview',
+    tel: 'Tel',
+    taxNo: 'Tax No',
+    commReg: 'Comm Reg',
+    receiptNum: 'Receipt #',
+    date: 'Date',
+    cashier: 'Cashier',
+    customer: 'Customer',
+    phone: 'Phone',
+    item: 'Item',
+    qty: 'Qty',
+    price: 'Price',
+    total: 'Total',
+    subtotal: 'Subtotal',
+    vat: 'VAT',
+    grandTotal: 'TOTAL',
+    payment: 'Payment',
+    cash: 'Cash',
+    card: 'Card',
+    installmentLabel: 'Installment',
+    other: 'Other',
+    afterDiscount: 'After Discount',
+    fixedDiscount: 'Fixed Discount',
+    percentOff: '% off',
+    installmentPlan: 'INSTALLMENT PLAN',
+    depositPaid: 'Deposit Paid',
+    remaining: 'Remaining',
+    installmentPayment: 'Payment',
+    walkIn: 'Walk-in Customer',
+    unknown: 'Unknown',
+    thankYou: 'Thank you for your visit!',
+    appreciate: 'We appreciate your business',
+    printBrowser: 'Print (Browser)',
+    printThermal: 'Print (Thermal)',
+    printing: 'Printing...',
+  }
 
   // Load settings on mount
   useEffect(() => {
@@ -122,8 +199,8 @@ export function ReceiptPreviewModal({ transaction, onClose }: ReceiptPreviewModa
 
       const shouldForceThermal = settings.printerType === 'none' || settings.printerType === 'html'
       const effectiveSettings = shouldForceThermal
-        ? { ...settings, printerType: 'usb' }
-        : settings
+        ? { ...settings, printerType: 'usb', receiptLanguage: receiptLang }
+        : { ...settings, receiptLanguage: receiptLang }
 
       // Print via IPC (auto-detect thermal on first print or fallback)
       const result = await window.api.thermalReceipts.print({
@@ -181,61 +258,76 @@ export function ReceiptPreviewModal({ transaction, onClose }: ReceiptPreviewModa
       <div className="bg-white dark:bg-slate-800 rounded-lg shadow-xl w-full max-w-md max-h-[90vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700">
-          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Receipt Preview</h2>
-          <button
-            onClick={onClose}
-            className="p-1 hover:bg-slate-100 dark:hover:bg-slate-700 rounded transition-colors text-slate-600 dark:text-slate-300"
-          >
-            <X className="w-5 h-5" />
-          </button>
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">{L.receiptPreview}</h2>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => {
+                const newLang = receiptLang === 'en' ? 'ar' : 'en'
+                setReceiptLang(newLang)
+                localStorage.setItem('receiptLanguage', newLang)
+              }}
+              className="px-2.5 py-1 text-xs font-bold bg-slate-100 dark:bg-slate-700 hover:bg-primary/10 dark:hover:bg-primary/20 text-slate-700 dark:text-slate-200 rounded border border-slate-300 dark:border-slate-600 transition-colors"
+              title="Toggle receipt language"
+            >
+              {receiptLang === 'en' ? 'عربي' : 'EN'}
+            </button>
+            <button
+              onClick={onClose}
+              className="p-1 hover:bg-slate-100 dark:hover:bg-slate-700 rounded transition-colors text-slate-600 dark:text-slate-300"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
         </div>
 
         {/* Receipt Preview */}
         <div className="flex-1 overflow-y-auto p-6 bg-slate-50 dark:bg-slate-900">
           <div 
-            className="bg-white shadow-lg mx-auto p-6 text-sm font-mono text-black"
-            style={{ width: settings.paperWidth === '80mm' ? '302px' : '203px' }}
+            className="bg-white shadow-lg mx-auto p-6 text-sm text-black"
+            style={{
+              width: settings.paperWidth === '80mm' ? '302px' : '203px',
+              direction: receiptLang === 'ar' ? 'rtl' : 'ltr',
+              fontFamily: receiptLang === 'ar' ? 'Arial, Tahoma, sans-serif' : 'monospace',
+            }}
             id="receipt-preview"
           >
             {/* Store Name */}
             <div className="text-center mb-4">
               <h1 className="text-xl font-bold mb-1">{settings.storeName}</h1>
               <p className="text-xs">{settings.storeAddress}</p>
-              <p className="text-xs">Tel: {settings.storePhone}</p>
+              <p className="text-xs">{L.tel}: {settings.storePhone}</p>
               {settings.storeEmail && <p className="text-xs">{settings.storeEmail}</p>}
             </div>
 
             {/* Tax Info */}
             <div className="border-t border-b border-gray-300 py-2 mb-3 text-xs">
-              <p>Tax No: {settings.taxNumber}</p>
-              {settings.commercialRegister && <p>Comm Reg: {settings.commercialRegister}</p>}
+              <p>{L.taxNo}: {settings.taxNumber}</p>
+              {settings.commercialRegister && <p>{L.commReg}: {settings.commercialRegister}</p>}
             </div>
 
             {/* Receipt Details */}
             <div className="mb-3 text-xs space-y-1">
-              <p>Receipt #: {transaction.id.substring(0, 8).toUpperCase()}</p>
-              <p>Date: {new Date(transaction.createdAt).toLocaleString('en-US', {
-                year: 'numeric',
-                month: '2-digit',
-                day: '2-digit',
-                hour: '2-digit',
-                minute: '2-digit',
-                hour12: true
-              })}</p>
-              <p>Cashier: {transaction.user?.username || transaction.user?.fullName || 'Unknown'}</p>
-              <p>Customer: {transaction.Customer?.name || transaction.customerName || 'Walk-in Customer'}</p>              {(transaction.Customer?.phone || transaction.customer?.phone) && (
-                <p>Phone: {transaction.Customer?.phone || transaction.customer?.phone}</p>
-              )}            </div>
+              <p>{L.receiptNum}: {transaction.id.substring(0, 8).toUpperCase()}</p>
+              <p>{L.date}: {new Date(transaction.createdAt).toLocaleString(
+                receiptLang === 'ar' ? 'ar-EG' : 'en-US',
+                { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: true }
+              )}</p>
+              <p>{L.cashier}: {transaction.user?.username || transaction.user?.fullName || L.unknown}</p>
+              <p>{L.customer}: {transaction.Customer?.name || transaction.customerName || L.walkIn}</p>
+              {(transaction.Customer?.phone || transaction.customer?.phone) && (
+                <p>{L.phone}: {transaction.Customer?.phone || transaction.customer?.phone}</p>
+              )}
+            </div>
 
             {/* Items Table */}
             <div className="border-t border-b border-gray-300 py-2 mb-3">
               <table className="w-full text-xs">
                 <thead>
                   <tr className="border-b border-gray-300">
-                    <th className="text-left pb-1">Item</th>
-                    <th className="text-center pb-1">Qty</th>
-                    <th className="text-center pb-1">Price</th>
-                    <th className="text-right pb-1">Total</th>
+                    <th className="text-left pb-1">{L.item}</th>
+                    <th className="text-center pb-1">{L.qty}</th>
+                    <th className="text-center pb-1">{L.price}</th>
+                    <th className="text-right pb-1">{L.total}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -272,9 +364,9 @@ export function ReceiptPreviewModal({ transaction, onClose }: ReceiptPreviewModa
                         </tr>
                         {hasDiscount && (
                           <tr className="border-b border-dashed border-gray-200 text-red-600">
-                            <td className="text-left py-1 text-xs">After Discount: {finalTotal.toFixed(2)} EGP</td>
+                            <td className="text-left py-1 text-xs">{L.afterDiscount}: {finalTotal.toFixed(2)} EGP</td>
                             <td colSpan={2} className="text-center py-1 text-xs italic">
-                              {item.discountType === 'PERCENTAGE' ? `${item.discountValue}% off` : 'Fixed Discount'}
+                              {item.discountType === 'PERCENTAGE' ? `${item.discountValue}${L.percentOff}` : L.fixedDiscount}
                             </td>
                             <td className="text-right py-1">-{itemDiscount.toFixed(2)} EGP</td>
                           </tr>
@@ -289,36 +381,36 @@ export function ReceiptPreviewModal({ transaction, onClose }: ReceiptPreviewModa
             {/* Totals */}
             <div className="text-xs space-y-1 mb-3">
               <div className="flex justify-between">
-                <span className="font-bold">Subtotal:</span>
+                <span className="font-bold">{L.subtotal}:</span>
                 <span>{transaction.subtotal.toFixed(2)} EGP</span>
               </div>
               <div className="flex justify-between">
-                <span>VAT ({settings.taxRate }%):</span>
+                <span>{L.vat} ({settings.taxRate}%):</span>
                 <span>{transaction.tax.toFixed(2)} EGP</span>
               </div>
               <div className="flex justify-between border-t border-gray-300 pt-1 text-base font-bold">
-                <span>TOTAL:</span>
+                <span>{L.grandTotal}:</span>
                 <span>{transaction.total.toFixed(2)} EGP</span>
               </div>
             </div>
 
             {/* Payment Method */}
             <div className="text-center text-xs mb-3">
-              <p>Payment: {
-                transaction.paymentMethod === 'cash' ? 'Cash' :
-                transaction.paymentMethod === 'card' ? 'Card' :
-                transaction.paymentMethod === 'installment' ? 'Installment' : 'Other'
+              <p>{L.payment}: {
+                transaction.paymentMethod === 'cash' ? L.cash :
+                transaction.paymentMethod === 'card' ? L.card :
+                transaction.paymentMethod === 'installment' ? L.installmentLabel : L.other
               }</p>
             </div>
 
             {/* Installment Details */}
             {transaction.installments && transaction.installments.length > 0 && (
               <div className="border-t border-gray-300 pt-3 mb-3">
-                <p className="text-xs font-bold mb-2 text-center">INSTALLMENT PLAN</p>
+                <p className="text-xs font-bold mb-2 text-center">{L.installmentPlan}</p>
                 {transaction.deposits && transaction.deposits.length > 0 && (
                   <div className="text-xs mb-2 bg-gray-100 p-2 rounded">
                     <div className="flex justify-between">
-                      <span>Deposit Paid:</span>
+                      <span>{L.depositPaid}:</span>
                       <span className="font-bold">{transaction.deposits[0].amount.toFixed(2)} EGP</span>
                     </div>
                   </div>
@@ -326,14 +418,14 @@ export function ReceiptPreviewModal({ transaction, onClose }: ReceiptPreviewModa
                 <div className="text-xs space-y-1">
                   {transaction.installments.map((inst: any, idx: number) => (
                     <div key={idx} className="flex justify-between items-center py-1 border-b border-dashed border-gray-200">
-                      <span>Payment {idx + 1}: {new Date(inst.dueDate).toLocaleDateString()}</span>
+                      <span>{L.installmentPayment} {idx + 1}: {new Date(inst.dueDate).toLocaleDateString(receiptLang === 'ar' ? 'ar-EG' : 'en-US')}</span>
                       <span className={`font-bold ${inst.status === 'paid' ? 'text-green-600' : inst.status === 'overdue' ? 'text-red-600' : ''}`}>
                         {inst.amount.toFixed(2)} EGP {inst.status === 'paid' ? '✓' : ''}
                       </span>
                     </div>
                   ))}
                   <div className="flex justify-between pt-2 font-bold">
-                    <span>Remaining:</span>
+                    <span>{L.remaining}:</span>
                     <span>{transaction.installments.filter((i: any) => i.status !== 'paid').reduce((sum: number, i: any) => sum + i.amount, 0).toFixed(2)} EGP</span>
                   </div>
                 </div>
@@ -342,8 +434,8 @@ export function ReceiptPreviewModal({ transaction, onClose }: ReceiptPreviewModa
 
             {/* Footer */}
             <div className="text-center text-xs border-t border-gray-300 pt-3">
-              <p>Thank you for your visit!</p>
-              <p>We appreciate your business</p>
+              <p>{L.thankYou}</p>
+              <p>{L.appreciate}</p>
             </div>
           </div>
         </div>
@@ -355,7 +447,7 @@ export function ReceiptPreviewModal({ transaction, onClose }: ReceiptPreviewModa
             className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-slate-100 hover:bg-slate-200 dark:bg-slate-700 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-200 rounded transition-colors font-medium"
           >
             <Printer className="w-4 h-4" />
-            Print (Browser)
+            {L.printBrowser}
           </button>
           
           <button
@@ -364,7 +456,7 @@ export function ReceiptPreviewModal({ transaction, onClose }: ReceiptPreviewModa
             className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-green-600 hover:bg-green-700 dark:bg-green-500 dark:hover:bg-green-600 disabled:bg-slate-400 dark:disabled:bg-slate-600 text-white rounded transition-colors font-medium"
           >
             <Printer className="w-4 h-4" />
-            {isPrinting ? 'Printing...' : 'Print (Thermal)'}
+            {isPrinting ? L.printing : L.printThermal}
           </button>
         </div>
       </div>

--- a/src/renderer/src/pages/Settings/TaxReceiptSettings.tsx
+++ b/src/renderer/src/pages/Settings/TaxReceiptSettings.tsx
@@ -270,6 +270,40 @@ export default function TaxReceiptSettings({ settings, onChange }: Props) {
           </p>
         </div>
 
+        {/* Receipt Language */}
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+            Receipt Language / لغة الإيصال
+          </label>
+          <div className="flex gap-4">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="receiptLanguage"
+                value="en"
+                checked={(settings.receiptLanguage || 'en') === 'en'}
+                onChange={(e) => handleChange('receiptLanguage', e.target.value)}
+                className="w-4 h-4 text-primary focus:ring-primary"
+              />
+              <span className="text-sm text-slate-700 dark:text-slate-300">English</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="receiptLanguage"
+                value="ar"
+                checked={settings.receiptLanguage === 'ar'}
+                onChange={(e) => handleChange('receiptLanguage', e.target.value)}
+                className="w-4 h-4 text-primary focus:ring-primary"
+              />
+              <span className="text-sm text-slate-700 dark:text-slate-300" dir="rtl">العربية</span>
+            </label>
+          </div>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Choose the language used for all receipt labels (thermal &amp; print preview).
+          </p>
+        </div>
+
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <label className="flex items-center gap-2 cursor-pointer">
             <input

--- a/src/renderer/src/pages/Settings/types.ts
+++ b/src/renderer/src/pages/Settings/types.ts
@@ -43,6 +43,7 @@ export interface TaxReceiptSettings {
   printQRCode: boolean
   printBarcode: boolean
   openCashDrawer: boolean
+  receiptLanguage: 'en' | 'ar'
 }
 
 export interface NotificationSettings {

--- a/src/renderer/src/pages/Settings/useSettings.ts
+++ b/src/renderer/src/pages/Settings/useSettings.ts
@@ -60,7 +60,8 @@ export function useSettings() {
       printLogo: localStorage.getItem('printLogo') === 'true',
       printQRCode: localStorage.getItem('printQRCode') === 'true',
       printBarcode: localStorage.getItem('printBarcode') === 'true',
-      openCashDrawer: localStorage.getItem('openCashDrawer') === 'true'
+      openCashDrawer: localStorage.getItem('openCashDrawer') === 'true',
+      receiptLanguage: (localStorage.getItem('receiptLanguage') as 'en' | 'ar') || 'en'
     }
   })
 


### PR DESCRIPTION
This pull request adds support for bilingual (English/Arabic) receipts throughout the thermal printing and receipt preview features. It introduces a new `receiptLanguage` setting, updates receipt label rendering and formatting for both languages, and provides a user interface for toggling the receipt language in the preview modal.

**Internationalization and Language Support:**

* Added a new `receiptLanguage` property to the `PrinterSettings` interface and implemented logic in `ThermalPrinterService` to use either English or Arabic for all receipt labels and text, including a helper method for label translation. [[1]](diffhunk://#diff-85c2907730a5fae58f57004ecc69b45be384ff92e746b1674f4dd4039c16fc14R29) [[2]](diffhunk://#diff-85c2907730a5fae58f57004ecc69b45be384ff92e746b1674f4dd4039c16fc14R152-R213)
* Updated all receipt text generation and printing logic in `ThermalPrinterService` to use translated labels and locale-specific date formatting, ensuring receipts are fully localized based on the selected language. [[1]](diffhunk://#diff-85c2907730a5fae58f57004ecc69b45be384ff92e746b1674f4dd4039c16fc14L164-R246) [[2]](diffhunk://#diff-85c2907730a5fae58f57004ecc69b45be384ff92e746b1674f4dd4039c16fc14L216-R310) [[3]](diffhunk://#diff-85c2907730a5fae58f57004ecc69b45be384ff92e746b1674f4dd4039c16fc14L261-R325) [[4]](diffhunk://#diff-85c2907730a5fae58f57004ecc69b45be384ff92e746b1674f4dd4039c16fc14R372-R373) [[5]](diffhunk://#diff-85c2907730a5fae58f57004ecc69b45be384ff92e746b1674f4dd4039c16fc14L322-R401) [[6]](diffhunk://#diff-85c2907730a5fae58f57004ecc69b45be384ff92e746b1674f4dd4039c16fc14L349-R416) [[7]](diffhunk://#diff-85c2907730a5fae58f57004ecc69b45be384ff92e746b1674f4dd4039c16fc14L385-R490) [[8]](diffhunk://#diff-85c2907730a5fae58f57004ecc69b45be384ff92e746b1674f4dd4039c16fc14L440-R508)

**Receipt Preview Modal Enhancements:**

* Added a language toggle button to the receipt preview modal, allowing users to switch between English and Arabic; the selected language is persisted in `localStorage`.
* Refactored all UI labels and receipt details in the modal to use the selected language, including table headers, item details, and summary fields. The preview also adjusts text direction and font family for Arabic. [[1]](diffhunk://#diff-780127db7b41ff69b617f42f7b2fe0dcfe4827911d211650860aad101eeae37eR16-R92) [[2]](diffhunk://#diff-780127db7b41ff69b617f42f7b2fe0dcfe4827911d211650860aad101eeae37eL275-R369)

**Printing Logic Update:**

* Ensured that the selected receipt language is passed to the thermal printer service when printing, so printed receipts match the preview language.