### PR TITLE
Fix GitHub Actions workflow failures

### DIFF
--- a/.github/workflows/build-desktop-release.yml
+++ b/.github/workflows/build-desktop-release.yml
@@ -54,7 +54,7 @@ jobs:
           ENABLED_MODULES: ${{ inputs.module }}
 
       - name: Package Windows installer
-        run: npx cross-env ENABLED_MODULES=${{ inputs.module }} electron-builder --win --x64
+        run: npx cross-env ENABLED_MODULES=${{ inputs.module }} CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --win --x64 --publish never
 
       - name: Normalize asset file name
         shell: pwsh
@@ -117,7 +117,7 @@ jobs:
           ENABLED_MODULES: ${{ inputs.module }}
 
       - name: Package macOS installer
-        run: npx cross-env ENABLED_MODULES=${{ inputs.module }} electron-builder --mac
+        run: npx cross-env ENABLED_MODULES=${{ inputs.module }} electron-builder --mac --publish never
 
       - name: Normalize asset file name
         run: |
@@ -179,7 +179,7 @@ jobs:
           ENABLED_MODULES: ${{ inputs.module }}
 
       - name: Package Linux AppImage
-        run: npx cross-env ENABLED_MODULES=${{ inputs.module }} electron-builder --linux AppImage
+        run: npx cross-env ENABLED_MODULES=${{ inputs.module }} electron-builder --linux AppImage --publish never
 
       - name: Normalize asset file name
         run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+          cache-dependency-path: apps/Bizflow/package-lock.json
       
       - name: Install dependencies
         working-directory: apps/Bizflow
@@ -156,7 +157,7 @@ jobs:
       
       - name: Package Windows installer
         working-directory: apps/Bizflow
-        run: npm run build:win
+        run: npx cross-env ENABLED_MODULES=all CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --win --x64 --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WINDOWS_CERTIFICATE_FILE: ${{ env.WINDOWS_CERTIFICATE_FILE }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,9 +21,10 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: apps/website/package-lock.json
 
       - name: Install website deps
+        working-directory: apps/website
         run: npm ci --legacy-peer-deps
 
       - name: Generate Prisma client

--- a/apps/Bizflow/electron-builder.yml
+++ b/apps/Bizflow/electron-builder.yml
@@ -94,8 +94,8 @@ appImage:
 npmRebuild: false
 publish:
   provider: github
-  owner: YOUR_GITHUB_USER_OR_ORG   # <-- set to your GitHub username or org
-  repo: YOUR_REPO_NAME             # <-- set to the repo that holds the Releases
+  owner: medhatjachour
+  repo: BizFlow
   releaseType: release
   # If you publish several plugin variants to the SAME repo, also set a per-variant
   # `channel:` here (and autoUpdater.channel in src/main/updater.ts) so their


### PR DESCRIPTION
This fixes the recent CI failures caused by workflow/package coordination issues in the monorepo. The deploy workflow was installing from the wrong directory for the website app, and the desktop packaging workflows were letting electron-builder attempt GitHub publishing with placeholder repo metadata.

## What changed
- point the deploy workflow's npm cache and install step at `apps/website`, so website validation uses the correct lockfile
- add the Bizflow app lockfile path to the Windows workflow cache config
- force desktop packaging workflows to build artifacts with `--publish never` and disable certificate auto-discovery for unsigned Windows CI builds
- replace placeholder GitHub publish metadata in `apps/Bizflow/electron-builder.yml` with the real `medhatjachour/BizFlow` repo

## Notes for reviewers
The main behavior change is that workflow packaging and release upload are now separated cleanly: electron-builder only creates artifacts, while the workflow handles release publication explicitly. This avoids the 404 failure path and keeps release behavior predictable across Windows, macOS, and Linux.

## Testing
- `npm ci --workspace apps/website --legacy-peer-deps`
- `npm ci --legacy-peer-deps`